### PR TITLE
Add functionality to undo a chain of recent commands

### DIFF
--- a/src/main/java/mei/Mei.java
+++ b/src/main/java/mei/Mei.java
@@ -40,7 +40,7 @@ public class Mei {
      * @param userInput The user input to redirect and get a response out of.
      */
     public void redirectInputToSetResponses(String userInput) {
-        inputManager.redirectInput(userInput);
+        inputManager.redirectInput(userInput, false);
     }
 
 }

--- a/src/main/java/mei/exception/DeadlineNotEnoughInfoException.java
+++ b/src/main/java/mei/exception/DeadlineNotEnoughInfoException.java
@@ -4,8 +4,6 @@ package mei.exception;
  * Represents the Mei exception that is thrown when the deadline task given does not provide enough information to be interpreted.
  * echoErrorResponse should be called when this exception is caught.
  * This is classified as a task-related exception.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class DeadlineNotEnoughInfoException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {

--- a/src/main/java/mei/exception/EmptyMostRecentReversedInputException.java
+++ b/src/main/java/mei/exception/EmptyMostRecentReversedInputException.java
@@ -1,0 +1,16 @@
+package mei.exception;
+
+/**
+ * Represents the Mei exception that is thrown when the most recent reversed input is empty.
+ * echoErrorResponse should be called when this exception is caught.
+ * This is classified as an input-related exception.
+ */
+public class EmptyMostRecentReversedInputException extends MeiException {
+    private static final String[] ERROR_RESPONSES = new String[] {
+        "It seems that there are nothing to undo!"
+    };
+
+    public EmptyMostRecentReversedInputException() {
+        super(ERROR_RESPONSES);
+    }
+}

--- a/src/main/java/mei/exception/EmptyTaskDescriptionException.java
+++ b/src/main/java/mei/exception/EmptyTaskDescriptionException.java
@@ -4,8 +4,6 @@ package mei.exception;
  * Represents the Mei exception that is thrown when the new task given does not have a description.
  * echoErrorResponse should be called when this exception is caught.
  * This is classified as a task-related exception.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class EmptyTaskDescriptionException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {

--- a/src/main/java/mei/exception/EventNotEnoughInfoException.java
+++ b/src/main/java/mei/exception/EventNotEnoughInfoException.java
@@ -4,8 +4,6 @@ package mei.exception;
  * Represents the Mei exception that is thrown when the event task given does not provide enough information to be interpreted.
  * echoErrorResponse should be called when this exception is caught.
  * This is classified as a task-related exception.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class EventNotEnoughInfoException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {

--- a/src/main/java/mei/exception/TaskIndexOutOfBoundsException.java
+++ b/src/main/java/mei/exception/TaskIndexOutOfBoundsException.java
@@ -5,13 +5,11 @@ package mei.exception;
  * The task index is invalid if it falls outside the bounds (i.e. not an index held by any existing task.).
  * echoErrorResponse should be called when this exception is caught.
  * This is classified as a task-related exception.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class TaskIndexOutOfBoundsException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {
         "Hmm..? This task number doesn't seem to be"
-            + "on the list...", "Can you repeat with a valid one? :3"
+            + " on the list...", "Can you repeat with a valid one? :3"
     };
 
     public TaskIndexOutOfBoundsException() {

--- a/src/main/java/mei/exception/UnknownTaskTypeException.java
+++ b/src/main/java/mei/exception/UnknownTaskTypeException.java
@@ -5,8 +5,6 @@ package mei.exception;
  * The task type is invalid if it does not exist in the TASK_TYPES list defined within the Task Manager class.
  * echoErrorResponse should be called when this exception is caught.
  * This is classified as a task-related exception.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class UnknownTaskTypeException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {

--- a/src/main/java/mei/exception/UnknownUserInputException.java
+++ b/src/main/java/mei/exception/UnknownUserInputException.java
@@ -4,8 +4,6 @@ package mei.exception;
  * Represents the Mei exception that is thrown when the user gives an input undefined to Mei.
  * The input known to Mei are all specified in the redirectInput function within the Input Manager class.
  * echoErrorResponse should be called when this exception is caught.
- * The error response is given based on the string array retrieved from the RESPONSE_MAP in the Response Manager
- * with the key of the same name excluding the exception word at the end.
  */
 public class UnknownUserInputException extends MeiException {
     private static final String[] ERROR_RESPONSES = new String[] {

--- a/src/main/java/mei/fileaccess/FileRead.java
+++ b/src/main/java/mei/fileaccess/FileRead.java
@@ -5,10 +5,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Scanner;
 
-import mei.tasks.Deadline;
-import mei.tasks.Event;
-import mei.tasks.Task;
-import mei.tasks.ToDo;
+import mei.task.Deadline;
+import mei.task.Event;
+import mei.task.Task;
+import mei.task.ToDo;
 
 /**
  * Represents a class that acts as a utility to read from the designated file path.
@@ -51,7 +51,7 @@ public class FileRead {
 
     private Task processFileTaskData(String fileData) {
         String splitTaskFileDataRegex = "\\|";
-        String[] splitFileData = fileData.split(splitTaskFileDataRegex, 5);
+        String[] splitFileData = fileData.split(splitTaskFileDataRegex, 6);
         Task newTask = null;
 
         // Extract the necessary task fields.
@@ -61,16 +61,21 @@ public class FileRead {
 
         switch (taskType) {
         case "ToDo":
-            newTask = new ToDo(description);
+            String addTodoTaskCommand = splitFileData[3];
+            newTask = new ToDo(description, addTodoTaskCommand);
             break;
+
         case "Deadline":
             String deadlineDateTime = splitFileData[3];
-            newTask = new Deadline(description, deadlineDateTime);
+            String addDeadlineTaskCommand = splitFileData[4];
+            newTask = new Deadline(description, deadlineDateTime, addDeadlineTaskCommand);
             break;
+
         case "Event":
             String startDateTime = splitFileData[3];
             String endDateTime = splitFileData[4];
-            newTask = new Event(description, startDateTime, endDateTime);
+            String addEventTaskCommand = splitFileData[5];
+            newTask = new Event(description, startDateTime, endDateTime, addEventTaskCommand);
             break;
 
         default:

--- a/src/main/java/mei/fileaccess/FileStorage.java
+++ b/src/main/java/mei/fileaccess/FileStorage.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents the storage class that is responsible for interacting directly with the file-related calls.

--- a/src/main/java/mei/fileaccess/FileWrite.java
+++ b/src/main/java/mei/fileaccess/FileWrite.java
@@ -9,7 +9,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents a class that acts as a utility to write to the designated file path.

--- a/src/main/java/mei/javafx/Main.java
+++ b/src/main/java/mei/javafx/Main.java
@@ -14,7 +14,7 @@ import mei.Mei;
  * Represents the main class for this application.
  */
 public class Main extends Application {
-    private Mei mei = new Mei("./taskdata/tasks.txt");
+    private Mei mei = new Mei("./../taskdata/tasks.txt");
 
     @Override
     public void start(Stage stage) {

--- a/src/main/java/mei/manager/InputManager.java
+++ b/src/main/java/mei/manager/InputManager.java
@@ -36,8 +36,11 @@ public class InputManager {
      * This method can only receive a limited number of commands based on the keyword
      * (i.e. the first word of the given input.)
      * and the command is assumed to be a task command if none of the defined cases match.
+     * <p>
+     * Handles undo-ing of user command.
      *
      * @param input The user input to redirect.
+     * @param isUndoCommand Whether this input is an undo command.
      */
     public void redirectInput(String input, boolean isUndoCommand) {
         String[] splitInput = input.split(" ", 2);

--- a/src/main/java/mei/manager/InputManager.java
+++ b/src/main/java/mei/manager/InputManager.java
@@ -15,6 +15,7 @@ import mei.task.Task;
  *  Represents the manager for all user inputs towards the interaction with Mei.
  *  This class contains methods to interpret user input and redirect it to the appropriate managers.
  *  Acts as the middle-man between the user and other managers.
+ *  This manager also maintains a list of undo commands that the user can call undo on.
  */
 public class InputManager {
     private static List<String> mostRecentUndoCommands = new ArrayList<>();

--- a/src/main/java/mei/manager/InputManager.java
+++ b/src/main/java/mei/manager/InputManager.java
@@ -1,6 +1,11 @@
 package mei.manager;
 
-import mei.exception.*;
+import mei.exception.EmptyMostRecentReversedInputException;
+import mei.exception.EmptyTaskDescriptionException;
+import mei.exception.MeiException;
+import mei.exception.TaskIndexOutOfBoundsException;
+import mei.exception.UnknownTaskTypeException;
+import mei.exception.UnknownUserInputException;
 import mei.task.Task;
 
 /**
@@ -34,7 +39,7 @@ public class InputManager {
      *
      * @param input The user input to redirect.
      */
-    public void redirectInput(String input) {
+    public void redirectInput(String input, boolean isUndoCommand) {
         String[] splitInput = input.split(" ", 2);
         String keyword = splitInput[0];
         boolean shouldUpdateMostRecentReversedInput = false;
@@ -66,7 +71,12 @@ public class InputManager {
 
         default:
             shouldUpdateMostRecentReversedInput = isSuccessRedirectToAddTask(splitInput);
+        }
 
+        // Reset the most recent reversed input if undo-ing.
+        if (isUndoCommand) {
+            mostRecentReversedInput = null;
+            return;
         }
 
         if (shouldUpdateMostRecentReversedInput) {
@@ -184,7 +194,8 @@ public class InputManager {
             }
             assert !mostRecentReversedInput.isEmpty()
                     : "most recent reversed input must be initialized.";
-            redirectInput(mostRecentReversedInput);
+
+            redirectInput(mostRecentReversedInput, true);
 
         } catch (EmptyMostRecentReversedInputException e) {
             e.echoErrorResponse();

--- a/src/main/java/mei/manager/ResponseManager.java
+++ b/src/main/java/mei/manager/ResponseManager.java
@@ -6,7 +6,7 @@ import mei.response.FindTasksResponse;
 import mei.response.ListTasksResponse;
 import mei.response.MarkTaskResponse;
 import mei.response.UnmarkTaskResponse;
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * This is the manager responsible for managing Mei's responses.
@@ -36,7 +36,6 @@ public class ResponseManager {
 
         AddTaskResponse addTaskResponse = new AddTaskResponse(task, totalTasks);
         addTaskResponse.formResponsesAndSet();
-       
     }
 
     /**

--- a/src/main/java/mei/response/AddTaskResponse.java
+++ b/src/main/java/mei/response/AddTaskResponse.java
@@ -1,6 +1,6 @@
 package mei.response;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents the response to the user when adding a new task.

--- a/src/main/java/mei/response/DeleteTaskResponse.java
+++ b/src/main/java/mei/response/DeleteTaskResponse.java
@@ -1,6 +1,6 @@
 package mei.response;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents the response to the user when deleting an existing task.

--- a/src/main/java/mei/response/MarkTaskResponse.java
+++ b/src/main/java/mei/response/MarkTaskResponse.java
@@ -1,6 +1,6 @@
 package mei.response;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents the response to mark an existing user task.

--- a/src/main/java/mei/response/UnmarkTaskResponse.java
+++ b/src/main/java/mei/response/UnmarkTaskResponse.java
@@ -1,6 +1,6 @@
 package mei.response;
 
-import mei.tasks.Task;
+import mei.task.Task;
 
 /**
  * Represents the response to unmark an existing user task.

--- a/src/main/java/mei/stub/FileStorageStub.java
+++ b/src/main/java/mei/stub/FileStorageStub.java
@@ -1,9 +1,6 @@
 package mei.stub;
 
 import mei.fileaccess.FileStorage;
-import mei.tasks.Task;
-
-import java.util.ArrayList;
 
 /**
  * Represents a stub class for the file storage.

--- a/src/main/java/mei/task/Deadline.java
+++ b/src/main/java/mei/task/Deadline.java
@@ -1,4 +1,4 @@
-package mei.tasks;
+package mei.task;
 
 import java.time.LocalDateTime;
 
@@ -16,9 +16,10 @@ public class Deadline extends TimedTask {
      *
      * @param description The description of this task.
      * @param deadlineDateTime The deadline date/time of this task.
+     * @param addTaskCommand The command used to add this task.
      */
-    public Deadline(String description, String deadlineDateTime) {
-        super(description);
+    public Deadline(String description, String deadlineDateTime, String addTaskCommand) {
+        super(description, addTaskCommand);
         this.deadlineDateTime = convertDateTimeFormat(deadlineDateTime);
     }
 
@@ -29,8 +30,20 @@ public class Deadline extends TimedTask {
      * @return The string representation for writing to the save file.
      */
     public String getTaskDataString() {
-        return toRunTimeClassString() + "|" + getTaskStatusString() + "|" + super.description + "|"
-                + toFormattedDateTimeInputString(deadlineDateTime);
+        return toRunTimeClassString()
+                + "|" + getTaskStatusString()
+                + "|" + super.description
+                + "|" + toFormattedDateTimeInputString(deadlineDateTime)
+                + "|" + super.addTaskCommand;
+    }
+
+    /**
+     * Represents the current task as the command used when it was first added.
+     *
+     * @return The add task command string.
+     */
+    public String toAddTaskCommandString() {
+        return addTaskCommand;
     }
 
     /**

--- a/src/main/java/mei/task/Event.java
+++ b/src/main/java/mei/task/Event.java
@@ -1,4 +1,4 @@
-package mei.tasks;
+package mei.task;
 
 import java.time.LocalDateTime;
 
@@ -19,9 +19,10 @@ public class Event extends TimedTask {
      * @param description The description of this task.
      * @param startDateTime The starting date/time of this task.
      * @param endDateTime The ending date/time of this task.
+     * @param addTaskCommand The command used to add this task.
      */
-    public Event(String description, String startDateTime, String endDateTime) {
-        super(description);
+    public Event(String description, String startDateTime, String endDateTime, String addTaskCommand) {
+        super(description, addTaskCommand);
         this.startDateTime = convertDateTimeFormat(startDateTime);
         this.endDateTime = convertDateTimeFormat(endDateTime);
     }
@@ -33,8 +34,12 @@ public class Event extends TimedTask {
      * @return The string representation for writing to the save file.
      */
     public String getTaskDataString() {
-        return toRunTimeClassString() + "|" + getTaskStatusString() + "|" + super.description + "|"
-                + toFormattedDateTimeInputString(startDateTime) + "|" + toFormattedDateTimeInputString(endDateTime);
+        return toRunTimeClassString()
+                + "|" + getTaskStatusString()
+                + "|" + super.description
+                + "|" + toFormattedDateTimeInputString(startDateTime)
+                + "|" + toFormattedDateTimeInputString(endDateTime)
+                + "|" + super.addTaskCommand;
     }
 
     /**

--- a/src/main/java/mei/task/Task.java
+++ b/src/main/java/mei/task/Task.java
@@ -1,4 +1,4 @@
-package mei.tasks;
+package mei.task;
 
 /**
  * Represents the base class for all tasks.
@@ -6,6 +6,7 @@ package mei.tasks;
  */
 public class Task {
     protected final String description;
+    protected final String addTaskCommand;
     private boolean isTaskDone;
 
     /**
@@ -14,10 +15,12 @@ public class Task {
      * So that display and save formats will ignore leading and trailing spaces.
      *
      * @param description The description of this task.
+     * @param addTaskCommand The command used to add this task.
      */
-    public Task(String description) {
+    public Task(String description, String addTaskCommand) {
         this.description = description.trim();
         this.isTaskDone = false;
+        this.addTaskCommand = addTaskCommand;
     }
 
     /**
@@ -36,7 +39,10 @@ public class Task {
      * @return The string representation for writing to the save file.
      */
     public String getTaskDataString() {
-        return toRunTimeClassString() + "|" + getTaskStatusString() + "|" + description;
+        return toRunTimeClassString()
+                + "|" + getTaskStatusString()
+                + "|" + description
+                + "|" + addTaskCommand;
     }
 
     /**
@@ -66,6 +72,15 @@ public class Task {
 
     public String toRunTimeClassString() {
         return getClass().getSimpleName();
+    }
+
+    /**
+     * Gets the task's command when it was added.
+     *
+     * @return The add task command of this task.
+     */
+    public String getAddTaskCommand() {
+        return addTaskCommand;
     }
 
     /**

--- a/src/main/java/mei/task/TimedTask.java
+++ b/src/main/java/mei/task/TimedTask.java
@@ -1,4 +1,4 @@
-package mei.tasks;
+package mei.task;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -32,9 +32,10 @@ public class TimedTask extends Task {
      * into its LocalDateTime object.
      *
      * @param description The description of this task.
+     * @param addTaskCommand The command used to add this task.
      */
-    public TimedTask(String description) {
-        super(description);
+    public TimedTask(String description, String addTaskCommand) {
+        super(description, addTaskCommand);
         for (String format : INPUT_FORMATS) {
             INPUT_FORMATTERS.add(DateTimeFormatter.ofPattern(format));
         }

--- a/src/main/java/mei/task/ToDo.java
+++ b/src/main/java/mei/task/ToDo.java
@@ -1,4 +1,4 @@
-package mei.tasks;
+package mei.task;
 
 /**
  * Represents the todo task.
@@ -7,8 +7,16 @@ package mei.tasks;
  */
 public class ToDo extends Task {
 
-    public ToDo(String description) {
-        super(description);
+    /**
+     * Initializes a Todo task.
+     * The task description is trimmed.
+     * So that display and save formats will ignore leading and trailing spaces.
+     *
+     * @param description The description of this task.
+     * @param addTaskCommand The command used to add this task.
+     */
+    public ToDo(String description, String addTaskCommand) {
+        super(description, addTaskCommand);
     }
 
     /**

--- a/src/test/java/manager/ResponseManagerTest.java
+++ b/src/test/java/manager/ResponseManagerTest.java
@@ -69,7 +69,7 @@ public class ResponseManagerTest {
 
     @Test
     public void appendTaskStringToResponseArrayAndReturn_markTask_success() {
-        Task task = new Task("task 1");
+        Task task = new Task("task 1", "add task");
         MarkTaskResponse markTaskResponse = new MarkTaskResponse(task);
         task.completeTask();
         String taskString = task.toString();
@@ -88,7 +88,7 @@ public class ResponseManagerTest {
 
     @Test
     public void appendTaskStringToResponseArrayAndReturn_unmarkTask_success() {
-        Task task = new Task("task 1");
+        Task task = new Task("task 1", "add task");
         UnmarkTaskResponse unmarkTaskResponse = new UnmarkTaskResponse(task);
         String taskString = task.toString();
         String[] markTaskResponses = new String[] {

--- a/src/test/java/manager/ResponseManagerTest.java
+++ b/src/test/java/manager/ResponseManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import org.junit.jupiter.api.Test;
 
-import mei.tasks.Task;
+import mei.task.Task;
 import mei.response.MarkTaskResponse;
 import mei.response.Response;
 import mei.response.UnmarkTaskResponse;

--- a/src/test/java/manager/TaskManagerTest.java
+++ b/src/test/java/manager/TaskManagerTest.java
@@ -29,11 +29,11 @@ public class TaskManagerTest {
     public void getTaskStringsToDisplay_gotTasks_success() {
         FileStorageStub fs = new FileStorageStub("./");
         List<Task> tasks = new ArrayList<>();
-        tasks.add(new Task("task 1"));
-        tasks.add(new Task("task 2"));
-        tasks.add(new Task("task 3"));
-        tasks.add(new Task("task 4"));
-        tasks.add(new Task("task 5"));
+        tasks.add(new Task("task 1", "add task"));
+        tasks.add(new Task("task 2", "add task"));
+        tasks.add(new Task("task 3", "add task"));
+        tasks.add(new Task("task 4", "add task"));
+        tasks.add(new Task("task 5", "add task"));
 
         TaskManager tm = new TaskManager(tasks, fs);
         String[] actual = tm.getTaskStringsToDisplay();

--- a/src/test/java/manager/TaskManagerTest.java
+++ b/src/test/java/manager/TaskManagerTest.java
@@ -3,7 +3,7 @@ package manager;
 import mei.manager.TaskManager;
 import org.junit.jupiter.api.Test;
 import mei.stub.FileStorageStub;
-import mei.tasks.Task;
+import mei.task.Task;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/taskdata/tasks.txt
+++ b/taskdata/tasks.txt
@@ -1,2 +1,0 @@
-ToDo|[ ]|return book
-Deadline|[ ]|assignment 1|25/02/2026 1600


### PR DESCRIPTION
Caching a list of recent commands by reversing it (e.g. add -> delete,
mark -> unmark and vice versa) will allow execution of this
reversed command if undo is given as the input.

A modification to how the tasks are stored as data by including the
add task command is necessary to make the undo more versatile as we
don't have to manually change how is the add task command defined
for each task types in their classes whenever we decide to
change it.